### PR TITLE
Fix product list ajax rendering

### DIFF
--- a/public/static/index/index.js
+++ b/public/static/index/index.js
@@ -1,0 +1,260 @@
+(function (win, $) {
+    'use strict';
+
+    if (!$) {
+        return;
+    }
+
+    var productCache = [];
+    var groupedByCid = {};
+    var cidOrder = [];
+    var containers = ['#show-list-div', '#show-list-div-for-chengjiaoe', '#show-heng-div'];
+    var defaultIcon = '/tu/default.svg';
+    var hasInitialFetch = false;
+
+    function safeDecodePayload(payload) {
+        if (!payload) {
+            return null;
+        }
+
+        if (typeof payload !== 'string') {
+            return payload;
+        }
+
+        var trimmed = payload.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(trimmed);
+        } catch (err) {
+            try {
+                if (typeof Base64 !== 'undefined' && Base64 && typeof Base64.decode === 'function') {
+                    return JSON.parse(Base64.decode(trimmed));
+                }
+            } catch (e) {
+                console.error('Failed to decode Base64 payload', e);
+            }
+
+            try {
+                if (typeof atob === 'function') {
+                    return JSON.parse(atob(trimmed));
+                }
+            } catch (error) {
+                console.error('Failed to decode payload via atob', error);
+            }
+        }
+
+        return null;
+    }
+
+    function escapeHtml(text) {
+        if (text === null || text === undefined) {
+            return '';
+        }
+
+        return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function formatNumber(value) {
+        var num = parseFloat(value);
+        if (!isFinite(num)) {
+            return '--';
+        }
+
+        return num.toFixed(2);
+    }
+
+    function resolveIcon(item) {
+        var candidates = [item.icon, item.image, item.img, item.logo, item.pic, item.picurl, item.image_url];
+        for (var i = 0; i < candidates.length; i += 1) {
+            var candidate = candidates[i];
+            if (candidate && typeof candidate === 'string') {
+                var trimmed = candidate.trim();
+                if (trimmed && !/^javascript:/i.test(trimmed)) {
+                    return trimmed;
+                }
+            }
+        }
+        return defaultIcon;
+    }
+
+    function buildRow(item) {
+        var change = parseFloat(item.DiffRate);
+        if (!isFinite(change)) {
+            change = 0;
+        }
+        var changeText = (change > 0 ? '+' : '') + change.toFixed(2) + '%';
+        var isUp = Number(item.isup) === 1;
+        var isDown = Number(item.isup) === 0;
+        var changeClass = isUp ? 'p3' : (isDown ? 'p4' : 'p2');
+        var changeBg = isUp ? '#59bb5f' : (isDown ? '#ea4d3d' : '#90a2b0');
+
+        var html = '';
+        html += '<div class="Li" onclick="goToPage(' + encodeURIComponent(item.pid) + ')">';
+        html += '  <div class="left">';
+        html += '    <img src="' + escapeHtml(resolveIcon(item)) + '" alt="">';
+        html += '    <div>';
+        html += '      <p class="p1">' + escapeHtml(item.ptitle) + '</p>';
+        var code = item.procode || item.symbol || '';
+        html += '      <p class="p2">' + escapeHtml(code) + '</p>';
+        html += '    </div>';
+        html += '  </div>';
+        html += '  <div class="center">';
+        html += '    <p class="' + changeClass + '">' + formatNumber(item.Price) + '</p>';
+        html += '    <p class="p2">' + escapeHtml(item.UpdateTime || '') + '</p>';
+        html += '  </div>';
+        html += '  <div class="right">';
+        html += '    <div class="zf2" style="background:' + changeBg + ';">' + changeText + '</div>';
+        html += '  </div>';
+        html += '</div>';
+        return html;
+    }
+
+    function groupProducts(data) {
+        groupedByCid = {};
+        cidOrder = [];
+
+        data.forEach(function (item) {
+            var cid = item.cid;
+            if (cid === undefined || cid === null) {
+                cid = 'unknown';
+            }
+            if (!groupedByCid[cid]) {
+                groupedByCid[cid] = [];
+                cidOrder.push(cid);
+            }
+            groupedByCid[cid].push(item);
+        });
+
+        cidOrder.sort(function (a, b) {
+            var na = parseFloat(a);
+            var nb = parseFloat(b);
+            if (isFinite(na) && isFinite(nb)) {
+                return na - nb;
+            }
+            return String(a).localeCompare(String(b));
+        });
+    }
+
+    function refreshNavSummaries() {
+        var navItems = $('#nav .Li');
+        navItems.each(function (index, element) {
+            var $element = $(element);
+            var cid = cidOrder[index];
+            $element.attr('data-cid', cid || '');
+
+            var summary = '';
+            if (cid && groupedByCid[cid] && groupedByCid[cid].length) {
+                var first = groupedByCid[cid][0];
+                var change = parseFloat(first.DiffRate);
+                if (isFinite(change)) {
+                    summary = (change > 0 ? '+' : '') + change.toFixed(2) + '%';
+                }
+            }
+            $element.find('p').eq(1).text(summary);
+        });
+    }
+
+    function renderByIndex(index) {
+        var container = containers[index];
+        if (!container) {
+            return;
+        }
+        var cid = cidOrder[index];
+        if (!cid || !groupedByCid[cid]) {
+            $(container).empty();
+            return;
+        }
+        getonedata(cid, container);
+    }
+
+    function normaliseData(raw) {
+        if (!raw) {
+            return [];
+        }
+
+        if (Array.isArray(raw)) {
+            return raw;
+        }
+
+        if ($.isPlainObject(raw)) {
+            var result = [];
+            $.each(raw, function (key, value) {
+                if (value) {
+                    result.push(value);
+                }
+            });
+            return result;
+        }
+
+        return [];
+    }
+
+    function renderAll() {
+        groupProducts(productCache);
+        refreshNavSummaries();
+        for (var i = 0; i < containers.length; i += 1) {
+            renderByIndex(i);
+        }
+    }
+
+    function ajaxpro() {
+        hasInitialFetch = true;
+        var url = '/index/index/ajaxindexpro.html';
+        $.get(url, function (response) {
+            var parsed = safeDecodePayload(response);
+            var data = normaliseData(parsed);
+            if (!data.length) {
+                console.warn('ajaxpro: empty product list');
+                return;
+            }
+            productCache = data;
+            renderAll();
+        }).fail(function (xhr, status, error) {
+            console.error('ajaxpro request failed', status, error);
+        });
+    }
+
+    function getonedata(cid, container) {
+        if (!cid || !groupedByCid[cid]) {
+            if (container) {
+                $(container).empty();
+            }
+            return;
+        }
+
+        var list = groupedByCid[cid];
+        var html = '';
+        for (var i = 0; i < list.length; i += 1) {
+            html += buildRow(list[i]);
+        }
+
+        if (container) {
+            $(container).html(html);
+        }
+
+        return html;
+    }
+
+    win.ajaxpro = ajaxpro;
+    win.getonedata = getonedata;
+
+    $(function () {
+        if (!hasInitialFetch) {
+            ajaxpro();
+        }
+        setInterval(ajaxpro, 60000);
+
+        $('#nav .Li').on('click', function () {
+            var index = $('#nav .Li').index(this);
+            renderByIndex(index);
+        });
+    });
+}(window, window.jQuery));

--- a/tu/default.svg
+++ b/tu/default.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="symbol placeholder">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d6d9e1"/>
+      <stop offset="100%" stop-color="#b0b4c0"/>
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="62" height="62" rx="12" ry="12" fill="url(#g)" stroke="#959aa7" stroke-width="2"/>
+  <path d="M32 16c-8.837 0-16 7.163-16 16s7.163 16 16 16 16-7.163 16-16-7.163-16-16-16zm0 6a10 10 0 110 20 10 10 0 010-20z" fill="#6b7180"/>
+  <path d="M32 22a10 10 0 00-10 10h6a4 4 0 118 0h6a10 10 0 00-10-10z" fill="#f7f8fa" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a dedicated front-end script to decode ajax responses, group products by `cid`, and render each tab without hardcoded codes
- provide a default `/tu/default.svg` icon that is used whenever a product is missing its own image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df2c9335f083228bacad47cd369c1c

## Summary by Sourcery

Implement dynamic AJAX-driven product list rendering grouped by category with safe payload decoding and placeholder icons

New Features:
- Add front-end script to fetch and decode product data via AJAX and cache results
- Group products by category ID and dynamically render each tab’s content and navigation summaries
- Provide a default SVG icon fallback for products missing their own images